### PR TITLE
refactor: remove react-native-google-drive-api-wrapper dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,80 @@
 # ☁️ react-native-cloud-storage
 
-Save to & read from iCloud and Google Drive using React Native
-
 ![npm bundle size](https://img.shields.io/bundlephobia/min/react-native-cloud-storage?style=flat-square) ![GitHub](https://img.shields.io/github/license/kuatsu/react-native-cloud-storage?style=flat-square) ![GitHub last commit](https://img.shields.io/github/last-commit/kuatsu/react-native-cloud-storage?style=flat-square)
+
+This library provides a unified and streamlined API for accessing cloud storage services on iOS, Android and Web. It supports iCloud on iOS and Google Drive on all other platforms.
+
+- 💾 Read and write files to the cloud
+- 🧪 Fully compatible with Expo
+- 📱 iOS, Android & Web support
+- 🏎️ Lightning fast iCloud performance using native iOS APIs
+- 🌐 Google Drive REST API implementation for other platforms
+- 🧬 Easy to use React Hooks API, or use the imperative `fs`-style API
+- 👌 Zero dependencies, small bundle size
 
 ## Installation
 
+### React Native
+
 ```sh
 npm install react-native-cloud-storage
-# or
-yarn add react-native-cloud-storage
+cd ios && pod install
+```
+
+Afterwards, follow the [configuration instructions](https://react-native-cloud-storage.oss.kuatsu.de/docs/installation/react-native).
+
+### Expo
+
+```sh
+npx expo install react-native-cloud-storage
+```
+
+Afterwards, [add the provided config plugin](https://react-native-cloud-storage.oss.kuatsu.de/docs/installation/expo) and `expo prebuild` or rebuild your development client.
+
+## Quick Start
+
+```jsx
+import React from 'react';
+import { Platform, View, Text, Button } from 'react-native';
+import { CloudStorage, useCloudAvailable } from 'react-native-cloud-storage';
+
+const App = () => {
+  const cloudAvailable = useCloudAvailable();
+
+  React.useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      CloudStorage.setGoogleDriveAccessToken('some-access-token'); // get via @react-native-google-signin/google-signin or similar
+    }
+  }, []);
+
+  const writeToCloud = async () => {
+    await CloudStorage.writeFile('/file.txt', 'Hello, world!');
+    console.log('Successfully wrote file to cloud');
+  };
+
+  const readFromCloud = async () => {
+    const value = await CloudStorage.readFile('/file.txt');
+    console.log('Successfully read file from cloud:', value);
+  };
+
+  return (
+    <View>
+      {cloudAvailable ? (
+        <>
+          <Button onPress={writeToCloud} title="Write to Cloud" />
+          <Button onPress={readFromCloud} title="Read from Cloud" />
+        </>
+      ) : (
+        <Text>The cloud storage is not available. Are you logged in?</Text>
+      )}
+    </View>
+  );
+};
 ```
 
 ## Documentation
 
-The documentation is located [here](https://react-native-cloud-storage.oss.kuatsu.de/docs/intro).
+A detailed documentation is located [here](https://react-native-cloud-storage.oss.kuatsu.de/docs/intro).
 
 ## Contributing
 
@@ -22,12 +82,8 @@ See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the 
 
 ## Example Project
 
-There's a demo application available within the `example` directory. To use the Google Drive implementation for Android (and any other platforms except iOS), you'll need to provide a valid access token for the Google Drive API. You can create one using the [Google OAuth 2.0 Playground](https://developers.google.com/oauthplayground). If you're using an Android emulator, you can make your life easier by feeding the token into the emulator using `adb shell input text '{some_token}'`.
+There's an example app available in the `example` directory. To use the Google Drive implementation (for any platforms other than iOS), you'll need to provide a valid access token for the Google Drive API. For testing purposes, you can create one using the [Google OAuth 2.0 Playground](https://developers.google.com/oauthplayground).
 
 ## License
 
 MIT
-
----
-
-Made with [create-react-native-library](https://github.com/callstack/react-native-builder-bob)

--- a/docs/docs/api/CloudStorage.md
+++ b/docs/docs/api/CloudStorage.md
@@ -137,7 +137,7 @@ The access token is stored statically and therefore only needs to be provided on
 
 **Parameters**:
 
-- `accessToken` (`string`): Required. The access token to use.
+- `accessToken` (`string | null`): Required. The access token to use, or `null` to clear the currently stored access token.
 
 **Returns**: `void`
 

--- a/docs/docs/api/CloudStorage.md
+++ b/docs/docs/api/CloudStorage.md
@@ -74,7 +74,7 @@ Gets the currently stored default [`CloudStorageScope`](./enums/CloudStorageScop
 
 Gets the currently stored Google Drive access token (see [`setGoogleDriveAccessToken()`](#setgoogledriveaccesstokenaccesstoken)).
 
-**Returns**: A `Promise` that resolves to the `string` value of the access token, or `undefined` if it hasn't been set so far.
+**Returns**: A `Promise` that resolves to the `string` value of the access token, or `null` if it hasn't been set so far.
 
 ### `isCloudAvailable()`
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -375,7 +375,7 @@ PODS:
   - React-jsinspector (0.72.5)
   - React-logger (0.72.5):
     - glog
-  - react-native-cloud-storage (1.2.1):
+  - react-native-cloud-storage (1.2.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - react-native-safe-area-context (4.7.2):
@@ -698,7 +698,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: ff70a72027dea5cc7d71cfcc6fad7f599f63987a
   React-jsinspector: aef73cbd43b70675f572214d10fa438c89bf11ba
   React-logger: 2e4aee3e11b3ec4fa6cfd8004610bbb3b8d6cca4
-  react-native-cloud-storage: 65f4e4adeb74445f56ae7214e87450f246575afc
+  react-native-cloud-storage: 3af86738f814201ddaede5ce2b01b90e6eca867b
   react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
   React-NativeModulesApple: 797bc6078d566eef3fb3f74127e6e1d2e945a15f
   React-perflogger: cd8886513f68e1c135a1e79d20575c6489641597

--- a/example/src/views/Home.tsx
+++ b/example/src/views/Home.tsx
@@ -38,7 +38,7 @@ const HomeView = () => {
   }, []);
 
   useEffect(() => {
-    CloudStorage.setGoogleDriveAccessToken(accessToken);
+    CloudStorage.setGoogleDriveAccessToken(accessToken.length ? accessToken : null);
   }, [accessToken]);
 
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -183,8 +183,5 @@
         }
       ]
     ]
-  },
-  "dependencies": {
-    "react-native-google-drive-api-wrapper-js": "^1.2.3"
   }
 }

--- a/src/RNCloudStorage.ts
+++ b/src/RNCloudStorage.ts
@@ -11,7 +11,7 @@ const RNCloudStorage = {
   getDefaultScope: () => defaultScope,
   setDefaultScope: (scope: CloudStorageScope) => (defaultScope = scope),
   getGoogleDriveAccessToken: () => GoogleDrive.accessToken,
-  setGoogleDriveAccessToken: (accessToken: string) => (GoogleDrive.accessToken = accessToken),
+  setGoogleDriveAccessToken: (accessToken: string | null) => (GoogleDrive.accessToken = accessToken),
   setThrowOnFilesWithSameName: (enable: boolean) => (GoogleDrive.throwOnFilesWithSameName = enable),
   /* eslint-disable @typescript-eslint/no-unused-vars */
   subscribeToFilesWithSameName:

--- a/src/RNCloudStorage.ts
+++ b/src/RNCloudStorage.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 import createRNCloudStorage from './createRNCloudStorage';
-import GoogleDriveApiClient from './google-drive';
+import GoogleDrive from './google-drive';
 import { CloudStorageScope, type CloudStorageFileStat } from './types/main';
 import { verifyLeadingSlash } from './utils/helpers';
 
@@ -10,15 +10,15 @@ let defaultScope = CloudStorageScope.AppData;
 const RNCloudStorage = {
   getDefaultScope: () => defaultScope,
   setDefaultScope: (scope: CloudStorageScope) => (defaultScope = scope),
-  getGoogleDriveAccessToken: () => GoogleDriveApiClient.accessToken,
-  setGoogleDriveAccessToken: (accessToken: string) => (GoogleDriveApiClient.accessToken = accessToken),
-  setThrowOnFilesWithSameName: (enable: boolean) => (GoogleDriveApiClient.throwOnFilesWithSameName = enable),
+  getGoogleDriveAccessToken: () => GoogleDrive.accessToken,
+  setGoogleDriveAccessToken: (accessToken: string) => (GoogleDrive.accessToken = accessToken),
+  setThrowOnFilesWithSameName: (enable: boolean) => (GoogleDrive.throwOnFilesWithSameName = enable),
   /* eslint-disable @typescript-eslint/no-unused-vars */
   subscribeToFilesWithSameName:
     Platform.OS === 'ios'
       ? // @ts-expect-error - subscriber is undefined; just a mock
         (subscriber: ({ path, fileIds }: { path: string; fileIds: string[] }) => void) => ({ remove: () => {} })
-      : (nativeInstance as GoogleDriveApiClient).subscribeToFilesWithSameName.bind(nativeInstance),
+      : (nativeInstance as GoogleDrive).subscribeToFilesWithSameName.bind(nativeInstance),
   /* eslint-enable @typescript-eslint/no-unused-vars */
 
   /**

--- a/src/createRNCloudStorage.ts
+++ b/src/createRNCloudStorage.ts
@@ -1,6 +1,6 @@
 import { NativeModules, Platform } from 'react-native';
 import type NativeRNCloudStorage from './types/native';
-import GoogleDriveApiClient from './google-drive';
+import GoogleDrive from './google-drive';
 import { CloudStorageErrorCode } from './types/native';
 import CloudStorageError from './utils/CloudStorageError';
 
@@ -49,5 +49,5 @@ export default function createRNCloudStorage(): NativeRNCloudStorage {
     );
   }
 
-  return new GoogleDriveApiClient();
+  return new GoogleDrive();
 }

--- a/src/google-drive/client.ts
+++ b/src/google-drive/client.ts
@@ -83,19 +83,7 @@ export default class GoogleDriveApiClient {
         queryParameters,
       });
 
-      files.push(
-        ...(response.files ?? []).map((file) => ({
-          id: file.id!,
-          kind: 'drive#file' as const,
-          mimeType: file.mimeType!,
-          name: file.name!,
-          parents: file.parents!,
-          spaces: file.spaces! as ('drive' | 'appDataFolder')[],
-          size: file.size,
-          createdTime: file.createdTime,
-          modifiedTime: file.modifiedTime,
-        }))
-      );
+      files.push(...response.files);
       pageToken = response.nextPageToken ?? undefined;
     } while (pageToken);
 

--- a/src/google-drive/client.ts
+++ b/src/google-drive/client.ts
@@ -1,0 +1,126 @@
+import type {
+  GoogleDriveFile,
+  GoogleDriveFileSpace,
+  GoogleDriveListOperationQueryParameters,
+  GoogleDriveListOperationResponse,
+} from './types';
+
+const BASE_URL = 'https://www.googleapis.com/drive/v3';
+
+// TODO: fetch timeout
+// TODO: properly handle errors
+// TODO: read file
+// TODO: write file
+// TODO: delete file
+export default class GoogleDriveApiClient {
+  public accessToken: string;
+
+  constructor(accessToken: string = '') {
+    this.accessToken = accessToken;
+  }
+
+  private buildQueryString(query: object): string {
+    let res = Object.entries(query)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => {
+        if (typeof value === 'boolean') return `${encodeURIComponent(key)}=${value ? 'true' : 'false'}`;
+        return `${encodeURIComponent(key)}=${encodeURIComponent(value!)}`;
+      })
+      .join('&');
+
+    if (res) {
+      res = `?${res}`;
+    }
+    return res;
+  }
+
+  private async request<T extends Record<string, any> | string | void = void>(
+    operation: `/${string}`,
+    { queryParameters, ...options }: RequestInit & { queryParameters?: object } = {}
+  ): Promise<T> {
+    let path = `${BASE_URL}${operation}`;
+    if (queryParameters) {
+      path += this.buildQueryString(queryParameters);
+    }
+
+    const response = await fetch(path, {
+      ...options,
+      headers: {
+        ...options.headers,
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      // TODO: handle different errors
+      // console.log((await response.json()).error.errors);
+      let errorMessage: string;
+      try {
+        errorMessage =
+          (await response.json()).error?.errors?.[0]?.message ?? `Request failed with status ${response.status}`;
+      } catch (e) {
+        errorMessage = `Request failed with status ${response.status}`;
+      }
+      throw new Error(errorMessage);
+    }
+
+    if (options?.headers && 'Accept' in options.headers && options.headers.Accept !== 'application/json') {
+      return response.text() as unknown as Promise<T>;
+    }
+    return response.json();
+  }
+
+  public async listFiles(space: GoogleDriveFileSpace): Promise<GoogleDriveFile[]> {
+    const files: GoogleDriveFile[] = [];
+    let pageToken: string | undefined;
+    const fields = ['id', 'kind', 'mimeType', 'name', 'parents', 'spaces', 'size', 'createdTime', 'modifiedTime'];
+    do {
+      const queryParameters: GoogleDriveListOperationQueryParameters = {
+        fields: `files(${fields.join(',')}),nextPageToken`,
+        spaces: space,
+      };
+      const response = await this.request<GoogleDriveListOperationResponse>(`/files`, {
+        queryParameters,
+      });
+
+      files.push(
+        ...(response.files ?? []).map((file) => ({
+          id: file.id!,
+          kind: 'drive#file' as const,
+          mimeType: file.mimeType!,
+          name: file.name!,
+          parents: file.parents!,
+          spaces: file.spaces! as ('drive' | 'appDataFolder')[],
+          size: file.size,
+          createdTime: file.createdTime,
+          modifiedTime: file.modifiedTime,
+        }))
+      );
+      pageToken = response.nextPageToken ?? undefined;
+    } while (pageToken);
+
+    return files;
+  }
+
+  public async getFile(fileId: string): Promise<GoogleDriveFile> {
+    const queryParameters: GoogleDriveListOperationQueryParameters = {
+      fields: ['id', 'kind', 'mimeType', 'name', 'parents', 'spaces', 'size', 'createdTime', 'modifiedTime'].join(','),
+    };
+    return this.request<GoogleDriveFile>(`/files/${fileId}`, {
+      queryParameters,
+    });
+  }
+
+  public async getFileText(fileId: string): Promise<string> {
+    return this.request<string>(`/files/${fileId}`, {
+      queryParameters: { alt: 'media' },
+      headers: { Accept: 'text/plain' },
+    });
+  }
+
+  public async deleteFile(fileId: string): Promise<void> {
+    return this.request(`/files/${fileId}`, {
+      method: 'DELETE',
+    });
+  }
+}

--- a/src/google-drive/client.ts
+++ b/src/google-drive/client.ts
@@ -63,14 +63,14 @@ export default class GoogleDriveApiClient {
 
     if (!response.ok) {
       let errorMessage: string;
+      let json: any = null;
       try {
-        const json = await response.json();
+        json = await response.json();
         errorMessage = json.error?.message ?? `Request failed with status ${response.status}`;
-        throw new GoogleDriveHttpError(errorMessage, response.status, await response.json());
       } catch (e) {
         errorMessage = `Request failed with status ${response.status}`;
-        throw new GoogleDriveHttpError(errorMessage, response.status, null);
       }
+      throw new GoogleDriveHttpError(errorMessage, response.status, json);
     }
 
     if (options?.headers && 'Accept' in options.headers && options.headers.Accept !== 'application/json') {

--- a/src/google-drive/index.ts
+++ b/src/google-drive/index.ts
@@ -39,7 +39,7 @@ export default class GoogleDrive implements NativeRNCloudStorage {
   }
 
   // when setting accessToken, set it on the GDrive instance
-  public static set accessToken(accessToken: string | undefined) {
+  public static set accessToken(accessToken: string | null) {
     GoogleDrive.drive.accessToken = accessToken ?? '';
 
     // emit an event for the useIsCloudAvailable hook

--- a/src/google-drive/index.ts
+++ b/src/google-drive/index.ts
@@ -1,4 +1,3 @@
-import { HttpError } from 'react-native-google-drive-api-wrapper-js';
 import type NativeRNCloudStorage from '../types/native';
 import {
   CloudStorageErrorCode,
@@ -8,7 +7,7 @@ import {
 import CloudStorageError from '../utils/CloudStorageError';
 import { MimeTypes, type GoogleDriveFile, type GoogleDriveFileSpace } from './types';
 import { DeviceEventEmitter } from 'react-native';
-import GoogleDriveApiClient from './client';
+import GoogleDriveApiClient, { GoogleDriveHttpError } from './client';
 
 // TODO: replace legacyDrive fully with new drive implementation
 /**
@@ -208,7 +207,7 @@ export default class GoogleDrive implements NativeRNCloudStorage {
       }
       return file.id;
     } catch (e: unknown) {
-      if (e instanceof HttpError && e.json?.error?.status === 'UNAUTHENTICATED') {
+      if (e instanceof GoogleDriveHttpError && e.json?.error?.status === 'UNAUTHENTICATED') {
         throw new CloudStorageError(
           `Could not authenticate with Google Drive`,
           CloudStorageErrorCode.AUTHENTICATION_FAILED,

--- a/src/google-drive/types.ts
+++ b/src/google-drive/types.ts
@@ -1,4 +1,14 @@
 export type GoogleDriveFileSpace = 'appDataFolder' | 'drive';
+
+export enum MimeTypes {
+  BINARY = 'application/octet-stream',
+  CSV = 'text/csv',
+  FOLDER = 'application/vnd.google-apps.folder',
+  JSON = 'application/json',
+  PDF = 'application/pdf',
+  TEXT = 'text/plain',
+}
+
 export interface GoogleDriveFile {
   id: string;
   kind: 'drive#file';

--- a/src/google-drive/types.ts
+++ b/src/google-drive/types.ts
@@ -1,13 +1,11 @@
+export type GoogleDriveFileSpace = 'appDataFolder' | 'drive';
 export interface GoogleDriveFile {
   id: string;
   kind: 'drive#file';
   mimeType: string;
   name: string;
   parents: string[];
-  spaces: ('appDataFolder' | 'drive')[];
-}
-
-export interface GoogleDriveDetailedFile extends GoogleDriveFile {
+  spaces: GoogleDriveFileSpace[];
   createdTime: string;
   modifiedTime: string;
   size?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -17123,7 +17123,6 @@ __metadata:
     react: 18.2.0
     react-native: 0.72.5
     react-native-builder-bob: ^0.20.0
-    react-native-google-drive-api-wrapper-js: ^1.2.3
     release-it: ^15.0.0
     typescript: ^5.0.2
   peerDependencies:
@@ -17135,17 +17134,6 @@ __metadata:
       optional: true
   languageName: unknown
   linkType: soft
-
-"react-native-google-drive-api-wrapper-js@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "react-native-google-drive-api-wrapper-js@npm:1.2.3"
-  dependencies:
-    base64-js: ^1.5.1
-    simple-common-utils: ^2.3.0
-    utf8: ^3.0.0
-  checksum: fef52aa307cc5e2f7dbb7003fc55f70a4e96c5f13a48e47af08fad77a2372b5ec2a62e3b26bf0433c129e7f1e88a8bd73541a7293e551c7825b033cea1d3b1a2
-  languageName: node
-  linkType: hard
 
 "react-native-safe-area-context@npm:^4.7.2":
   version: 4.7.2
@@ -18452,13 +18440,6 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 64c757b498cb8629ffa5f75485340594d2f8189e9b08700e69199069c8e3070fb3e255f7ab873c05dc0b3cec412aea7402e10a5990cb6a050bd33ba062a6c549
-  languageName: node
-  linkType: hard
-
-"simple-common-utils@npm:^2.3.0":
-  version: 2.6.0
-  resolution: "simple-common-utils@npm:2.6.0"
-  checksum: 55da0f82463ac668d106c97180c89cea888b943ddc7f9c7f6f259fec8418d394fd707d8e3adc5168d3ffd7bfac467d821e8caaea463c5ed53c4b4a1a29d72e29
   languageName: node
   linkType: hard
 
@@ -20094,13 +20075,6 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 5c639e0f8da3521d605f59ce5be9e094ca772bd44a4ce7322b055a6f58eeed8dda3c94cabd90c7a41fb6fa852210092008afe48f7038792fd47501f33299116a
-  languageName: node
-  linkType: hard
-
-"utf8@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "utf8@npm:3.0.0"
-  checksum: cb89a69ad9ab393e3eae9b25305b3ff08bebca9adc839191a34f90777eb2942f86a96369d2839925fea58f8f722f7e27031d697f10f5f39690f8c5047303e62d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR aims to remove the dependency on react-native-google-drive-api-wrapper(-js), effectively making react-native-cloud-storage dependency-free. This should also make it easier to maintain the Google Drive implementation and add new features.

To accomplish this, react-native-cloud-storage will include its own Google Drive API client (based on pure `fetch`). Unfortunately, there's no true native solution for Android like CloudKit on iOS. Even if we were to implement this natively on Android, the native code would have to speak with the REST API. Therefore, a JavaScript solution should still be easier to maintain.