### PR TITLE
fix(ios): install ubiquity observer only after emitter callback is bound

### DIFF
--- a/packages/react-native-cloud-storage/ios/RCTCloudStorageCloudKit.mm
+++ b/packages/react-native-cloud-storage/ios/RCTCloudStorageCloudKit.mm
@@ -32,16 +32,12 @@
 {
   if (self = [super init]) {
     _cloudStorageCloudKit = [CloudStorageCloudKit new];
-
-    __weak __typeof__(self) weakSelf = self;
-    _ubiquityIdentityObserver = [[NSNotificationCenter defaultCenter]
-        addObserverForName:NSUbiquityIdentityDidChangeNotification
-                    object:nil
-                     queue:nil
-                usingBlock:^(__unused NSNotification *notification) {
-                  __strong __typeof__(weakSelf) strongSelf = weakSelf;
-                  [strongSelf emitCloudAvailabilityChanged];
-                }];
+    // The ubiquity-identity observer is installed in -setEventEmitterCallback:
+    // rather than here, so it can only fire after the codegen event emitter's
+    // std::function has been bound. Otherwise a notification posted by iOS
+    // between -init and -setEventEmitterCallback: would invoke an empty
+    // std::function and crash the process with std::bad_function_call.
+    // See: https://github.com/kuatsu/react-native-cloud-storage/issues/59
   }
 
   return self;
@@ -58,6 +54,19 @@
 - (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
 {
   [super setEventEmitterCallback:eventEmitterCallbackWrapper];
+
+  if (_ubiquityIdentityObserver == nil) {
+    __weak __typeof__(self) weakSelf = self;
+    _ubiquityIdentityObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSUbiquityIdentityDidChangeNotification
+                    object:nil
+                     queue:nil
+                usingBlock:^(__unused NSNotification *notification) {
+                  __strong __typeof__(weakSelf) strongSelf = weakSelf;
+                  [strongSelf emitCloudAvailabilityChanged];
+                }];
+  }
+
   [self emitCloudAvailabilityChanged];
 }
 


### PR DESCRIPTION
## Summary

Fixes #59.

`RCTCloudStorageCloudKit` registered its `NSUbiquityIdentityDidChangeNotification` observer in `-init`, but the observer's block ends up calling the codegen-generated `-emitOnCloudAvailabilityChanged:`, which invokes a `std::function` event-emitter callback that is only bound later via `-setEventEmitterCallback:`.

If iOS posts the ubiquity-change notification in the window between `-init` and `-setEventEmitterCallback:` (e.g. on app launch after a reboot, when the user signs in/out of iCloud, or when iCloud Drive is toggled), the block invokes an empty `std::function`, throwing `std::bad_function_call` and terminating the process with `SIGABRT`.

## Fix

Move the observer installation into `-setEventEmitterCallback:` so it is only installed once the emitter callback is bound. `-dealloc` already removes the observer via the stored token, so no change needed there. The existing "emit current availability immediately after binding" behavior is preserved (we still call `emitCloudAvailabilityChanged` at the end of `-setEventEmitterCallback:`).

This matches the implementation approach proposed by @ayousufi in #59.

## Crash confirmation

Two independent reports against `react-native-cloud-storage@3.0.0` on iOS (New Architecture / Turbo Modules):

```
Exception Type: EXC_CRASH (SIGABRT)

 9 App  std::__1::__throw_bad_function_call[abi:ne200100]() + 52
10 App  std::__1::__function::__value_func<void (...)>::operator()(...) + 4
11 App  std::__1::function<void (...)>::operator()(...) + 92
12 App  -[NativeCloudStorageCloudKitIOSSpecBase emitOnCloudAvailabilityChanged:] + 64
13 App  -[RCTCloudStorageCloudKit emitCloudAvailabilityChanged] + 188
14 App  __31-[RCTCloudStorageCloudKit init]_block_invoke + 28
15 CoreFoundation  __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__
...
19 Foundation      -[NSNotificationCenter postNotificationName:object:userInfo:]
20 Foundation      ___postUbqiuityAccountChangeNotification_block_invoke
```

Reproduced on:
- iPhone 14 Pro / iOS 26.2 (#59)
- iPhone 17,2 / iOS 26.3.1 (crash log from TestFlight feedback)

## Testing

- Before: on a device that had iCloud state change recently, the app reliably crashes within seconds of launch. Also reproducible by toggling iCloud Drive off/on in Settings while the app is foregrounded.
- After: no crash in the same scenarios. The first emit after JS binds its listener still delivers the current availability correctly (because `setEventEmitterCallback:` continues to call `emitCloudAvailabilityChanged` at the end).

## Notes

- Android is unaffected — its module does not use an equivalent `NSNotificationCenter`-style observer.
- No API or JS-side change.